### PR TITLE
Adds AMD backend to loops

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,3 +101,96 @@ jobs:
       - name: Build
         # Cap parallelism (-j 2) for the same OOM reason as the Linux job.
         run: cmake --build build --config Release -j 2
+
+  backend-parity:
+    name: backend parity (xpu surface)
+    if: "!contains(github.event.head_commit.message, '[skip build]')"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Diff loops::xpu symbols across backend/{cuda,hip}.hxx
+        # The two backend files hand-mirror the same loops::xpu surface; a symbol
+        # added to one and forgotten in the other only fails when that backend is
+        # compiled. Diff the declared names (using / inline constexpr / inline fn)
+        # so the gap is caught in milliseconds, no toolchain required.
+        run: |
+          python3 - <<'PY'
+          import re, sys
+
+          def symbols(path):
+              text = open(path).read()
+              s = set()
+              s |= set(re.findall(r'^\s*using\s+(\w+)\s*=', text, re.M))
+              s |= set(re.findall(r'^\s*inline\s+constexpr\s+\w+\s+(\w+)\s*=', text, re.M))
+              s |= set(re.findall(r'^\s*inline\b.*?(\w+)\s*\(', text, re.M))
+              return s
+
+          cuda = symbols('include/loops/backend/cuda.hxx')
+          hip = symbols('include/loops/backend/hip.hxx')
+          only_cuda = sorted(cuda - hip)
+          only_hip = sorted(hip - cuda)
+          if only_cuda or only_hip:
+              print('loops::xpu surface mismatch between backend/cuda.hxx and backend/hip.hxx:')
+              if only_cuda:
+                  print('  only in cuda.hxx:', ', '.join(only_cuda))
+              if only_hip:
+                  print('  only in hip.hxx :', ', '.join(only_hip))
+              sys.exit(1)
+          print('loops::xpu surface matches across backends (%d symbols).' % len(cuda))
+          PY
+
+  hip:
+    name: linux / hip / rocm-7.2.4 / ${{ matrix.gfx }}
+    if: "!contains(github.event.head_commit.message, '[skip build]')"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    # ROCm 7.2.4 (latest at time of writing). The `-complete` image bundles the
+    # math stack (rocThrust / rocPRIM) the HIP backend links against. No GPU at
+    # the runner: building objects for --offload-arch=gfxXXX is offline-only, so
+    # the binaries are compiled but never run.
+    container:
+      image: rocm/dev-ubuntu-24.04:7.2.4-complete
+    env:
+      # Point find_package(hip/rocprim/rocthrust) at the ROCm install; the image
+      # ships them under /opt/rocm but does not put it on the default prefix path.
+      CMAKE_PREFIX_PATH: /opt/rocm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - gfx: gfx90a   # MI210 / MI250 (CDNA2)
+            preset: release-mi210
+          - gfx: gfx942   # MI300X / MI300A / MI325X (CDNA3)
+            preset: release-mi300x
+          - gfx: gfx950   # MI350X (CDNA4)
+            preset: release-mi350x
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: hipcc --version
+        run: hipcc --version
+
+      - name: Install build tools (cmake, git)
+        # The ROCm image ships neither a recent CMake (preset schema v6 +
+        # enable_language(HIP)) nor git (cxxopts is fetched via git clone),
+        # which the hosted ubuntu runners have by default. Add both.
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends python3-pip git ca-certificates
+          pip3 install --break-system-packages --no-cache-dir 'cmake>=3.28'
+          cmake --version
+
+      - name: 'Configure (preset: ${{ matrix.preset }})'
+        run: cmake --preset ${{ matrix.preset }}
+
+      - name: Build (compile-only, no GPU at runner)
+        # Cap -j 2 for the same OOM reason as the CUDA jobs (rocThrust-heavy
+        # hipcc). group_mapped is HIP-excluded (cooperative-groups), so the
+        # target set is the rest of the SpMV examples.
+        run: cmake --build build/${{ matrix.preset }} -j 2
+
+      - name: List built binaries
+        run: ls -la build/${{ matrix.preset }}/bin/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,10 +209,18 @@ set(LOOPS_HIP_RELEASE_FLAGS
   -ffast-math
 )
 
+# HIP marks its runtime functions warn_unused_result; the fire-and-forget xpu
+# wrappers (stream_synchronize, memcpy, ...) intentionally drop the status the
+# CUDA path also ignores, so quiet that one diagnostic on the AMD compiler.
+set(LOOPS_HIP_FLAGS
+  -Wno-unused-result
+)
+
 target_compile_options(loops INTERFACE
   $<$<COMPILE_LANGUAGE:CXX>:${LOOPS_HOST_WARNINGS}>
   $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:${LOOPS_CUDA_DEBUG_FLAGS}>
   $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<NOT:$<CONFIG:Debug>>>:${LOOPS_CUDA_RELEASE_FLAGS}>
+  $<$<COMPILE_LANGUAGE:HIP>:${LOOPS_HIP_FLAGS}>
   $<$<AND:$<COMPILE_LANGUAGE:HIP>,$<NOT:$<CONFIG:Debug>>>:${LOOPS_HIP_RELEASE_FLAGS}>
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,15 @@
 
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 
+# ----- Device backend selection -------------------------------------------
+# loops talks to the device runtime through loops::xpu (include/loops/util/
+# xpu.hxx), so the whole tree compiles on either vendor by flipping one switch:
+#   -DLOOPS_BACKEND=CUDA  (nvcc, default; existing builds unaffected)
+#   -DLOOPS_BACKEND=HIP   (hipcc / AMD ROCm)
+set(LOOPS_BACKEND "CUDA" CACHE STRING "Device backend: CUDA (nvcc) or HIP (hipcc/ROCm)")
+set_property(CACHE LOOPS_BACKEND PROPERTY STRINGS CUDA HIP)
+string(TOUPPER "${LOOPS_BACKEND}" LOOPS_BACKEND)
+
 # ----- Build type ---------------------------------------------------------
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(isMultiConfig)
@@ -18,30 +27,58 @@ else()
     "Debug;Release;RelWithDebInfo;MinSizeRel")
 endif()
 
-# ----- CUDA architecture selection ----------------------------------------
-# Default: detect the host GPU(s) (CMake 3.24+ supports `native`).
-# Override with -DCMAKE_CUDA_ARCHITECTURES="80;86;89;90" for multi-arch builds,
-# or pick a single arch like 90 for an H100-only build.
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES "native"
-      CACHE STRING "CUDA SM architectures (default: native auto-detect)")
+if(LOOPS_BACKEND STREQUAL "HIP")
+  # ----- AMD architecture selection ---------------------------------------
+  # Pick gfx target(s) (gfx90a MI210/MI250, gfx942 MI300/MI325, gfx950 MI350).
+  # A single-arch preset pins the compile-time launch_box tuning exactly;
+  # multi-arch builds fall back to the box's fallback entry.
+  if(NOT DEFINED CMAKE_HIP_ARCHITECTURES)
+    set(CMAKE_HIP_ARCHITECTURES "gfx942"
+        CACHE STRING "AMD gfx architectures")
+  endif()
+
+  project(loops
+    VERSION   0.2.0
+    LANGUAGES CXX C HIP
+    DESCRIPTION "An open-source GPU load-balancing framework"
+  )
+
+  message(STATUS "Loops version: ${PROJECT_VERSION}")
+  message(STATUS "Loops backend: HIP (ROCm)")
+  message(STATUS "Loops HIP architectures: ${CMAKE_HIP_ARCHITECTURES}")
+
+  # rocThrust / rocPRIM provide the thrust:: API on AMD; hip::host the runtime.
+  find_package(hip REQUIRED)
+  find_package(rocprim REQUIRED)
+  find_package(rocthrust REQUIRED)
+  message(STATUS "Found HIP ${hip_VERSION}")
+else()
+  # ----- CUDA architecture selection --------------------------------------
+  # Default: detect the host GPU(s) (CMake 3.24+ supports `native`).
+  # Override with -DCMAKE_CUDA_ARCHITECTURES="80;86;89;90" for multi-arch builds,
+  # or pick a single arch like 90 for an H100-only build.
+  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES "native"
+        CACHE STRING "CUDA SM architectures (default: native auto-detect)")
+  endif()
+
+  project(loops
+    VERSION   0.2.0
+    LANGUAGES CXX C CUDA
+    DESCRIPTION "An open-source GPU load-balancing framework"
+  )
+
+  message(STATUS "Loops version: ${PROJECT_VERSION}")
+  message(STATUS "Loops backend: CUDA")
+  message(STATUS "Loops CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
+
+  # ----- Toolkit & system dependencies ------------------------------------
+  # Provides imported targets: CUDA::cudart, CUDA::cuda_driver, CUDA::curand, ...
+  # CUDAToolkit is required (>= 11.7) and supplies the bundled Thrust + CUB
+  # headers via CUDAToolkit_INCLUDE_DIRS, so we no longer fetch them separately.
+  find_package(CUDAToolkit 11.7 REQUIRED)
+  message(STATUS "Found CUDA Toolkit ${CUDAToolkit_VERSION} at ${CUDAToolkit_BIN_DIR}")
 endif()
-
-project(loops
-  VERSION   0.2.0
-  LANGUAGES CXX C CUDA
-  DESCRIPTION "An open-source GPU load-balancing framework"
-)
-
-message(STATUS "Loops version: ${PROJECT_VERSION}")
-message(STATUS "Loops CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
-
-# ----- Toolkit & system dependencies --------------------------------------
-# Provides imported targets: CUDA::cudart, CUDA::cuda_driver, CUDA::curand, ...
-# CUDAToolkit is required (>= 11.7) and supplies the bundled Thrust + CUB
-# headers via CUDAToolkit_INCLUDE_DIRS, so we no longer fetch them separately.
-find_package(CUDAToolkit 11.7 REQUIRED)
-message(STATUS "Found CUDA Toolkit ${CUDAToolkit_VERSION} at ${CUDAToolkit_BIN_DIR}")
 
 # ----- Output directories -------------------------------------------------
 set(EXECUTABLE_OUTPUT_PATH "${PROJECT_BINARY_DIR}/bin"
@@ -62,7 +99,7 @@ option(LOOPS_USE_BUNDLED_CCCL "Use CUDA Toolkit's bundled Thrust/CUB instead of 
 include(${PROJECT_SOURCE_DIR}/cmake/FetchColors.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/FetchCXXOpts.cmake)
 
-if(NOT LOOPS_USE_BUNDLED_CCCL)
+if(LOOPS_BACKEND STREQUAL "CUDA" AND NOT LOOPS_USE_BUNDLED_CCCL)
   include(${PROJECT_SOURCE_DIR}/cmake/FetchCCCL.cmake)
 endif()
 
@@ -70,7 +107,11 @@ endif()
 add_library(loops INTERFACE)
 add_library(loops::loops ALIAS loops)
 
-target_compile_features(loops INTERFACE cxx_std_17 cuda_std_17)
+if(LOOPS_BACKEND STREQUAL "HIP")
+  target_compile_features(loops INTERFACE cxx_std_17 hip_std_17)
+else()
+  target_compile_features(loops INTERFACE cxx_std_17 cuda_std_17)
+endif()
 
 target_compile_definitions(loops
   INTERFACE
@@ -81,14 +122,30 @@ target_compile_definitions(loops
 
 # Bake the primary target arch into the kernels so the launch_box (util/
 # launch_box.hxx) resolves block size / items-per-thread to the GPU at compile
-# time. A single-arch preset (release-a100 -> 80, release-h100 -> 90) pins it
-# exactly; multi-arch / native builds leave it at the Ampere floor and rely on
-# each box's fallback entry plus the run-time grid sizing.
-list(LENGTH CMAKE_CUDA_ARCHITECTURES _loops_arch_count)
-if(_loops_arch_count EQUAL 1 AND CMAKE_CUDA_ARCHITECTURES MATCHES "^[0-9]+$")
-  target_compile_definitions(loops
-    INTERFACE LOOPS_TARGET_ARCH=${CMAKE_CUDA_ARCHITECTURES})
-  message(STATUS "Loops compile-time SpMV tuning: sm_${CMAKE_CUDA_ARCHITECTURES}")
+# time. A single-arch preset pins it exactly (release-a100 -> sm_80,
+# release-mi300x -> gfx942); multi-arch / native builds leave it at the
+# per-vendor floor and rely on each box's fallback entry plus run-time grid
+# sizing.
+if(LOOPS_BACKEND STREQUAL "HIP")
+  target_compile_definitions(loops INTERFACE LOOPS_BACKEND_HIP)
+  list(LENGTH CMAKE_HIP_ARCHITECTURES _loops_arch_count)
+  # Map a single gfx target (e.g. gfx942) to the hex id the launch_box keys on
+  # (LOOPS_TARGET_GFX=0x942); strip the leading sramecc/xnack feature suffix.
+  if(_loops_arch_count EQUAL 1)
+    string(REGEX REPLACE ":.*$" "" _loops_gfx "${CMAKE_HIP_ARCHITECTURES}")
+    if(_loops_gfx MATCHES "^gfx([0-9a-fA-F]+)$")
+      target_compile_definitions(loops
+        INTERFACE LOOPS_TARGET_GFX=0x${CMAKE_MATCH_1})
+      message(STATUS "Loops compile-time SpMV tuning: ${_loops_gfx}")
+    endif()
+  endif()
+else()
+  list(LENGTH CMAKE_CUDA_ARCHITECTURES _loops_arch_count)
+  if(_loops_arch_count EQUAL 1 AND CMAKE_CUDA_ARCHITECTURES MATCHES "^[0-9]+$")
+    target_compile_definitions(loops
+      INTERFACE LOOPS_TARGET_ARCH=${CMAKE_CUDA_ARCHITECTURES})
+    message(STATUS "Loops compile-time SpMV tuning: sm_${CMAKE_CUDA_ARCHITECTURES}")
+  endif()
 endif()
 
 target_include_directories(loops
@@ -98,20 +155,25 @@ target_include_directories(loops
     ${CXXOPTS_INCLUDE_DIR}
 )
 
-# Bundled Thrust/CUB headers come from the toolkit include dirs (CUDA >= 11.7).
-# When LOOPS_USE_BUNDLED_CCCL=OFF, FetchCCCL.cmake exposes CCCL::Thrust / CCCL::CUB.
-if(LOOPS_USE_BUNDLED_CCCL)
-  target_include_directories(loops INTERFACE ${CUDAToolkit_INCLUDE_DIRS})
+if(LOOPS_BACKEND STREQUAL "HIP")
+  # rocThrust pulls in rocPRIM and the thrust:: API; hip::host the runtime.
+  target_link_libraries(loops INTERFACE hip::host roc::rocthrust)
 else()
-  target_link_libraries(loops INTERFACE CCCL::Thrust CCCL::CUB CCCL::libcudacxx)
-endif()
+  # Bundled Thrust/CUB headers come from the toolkit include dirs (CUDA >= 11.7).
+  # When LOOPS_USE_BUNDLED_CCCL=OFF, FetchCCCL.cmake exposes CCCL::Thrust / CCCL::CUB.
+  if(LOOPS_USE_BUNDLED_CCCL)
+    target_include_directories(loops INTERFACE ${CUDAToolkit_INCLUDE_DIRS})
+  else()
+    target_link_libraries(loops INTERFACE CCCL::Thrust CCCL::CUB CCCL::libcudacxx)
+  endif()
 
-target_link_libraries(loops
-  INTERFACE
-    CUDA::cudart
-    CUDA::curand
-    CUDA::cuda_driver
-)
+  target_link_libraries(loops
+    INTERFACE
+      CUDA::cudart
+      CUDA::curand
+      CUDA::cuda_driver
+  )
+endif()
 
 # ----- Compile flags ------------------------------------------------------
 # Host-side warnings (CXX). NVCC forwards these via -Xcompiler.
@@ -141,26 +203,51 @@ set(LOOPS_CUDA_DEBUG_FLAGS
   -lineinfo
 )
 
+# HIP/clang takes extended lambdas and relaxed constexpr natively, so the
+# release knob is just fast math (the nvcc --use_fast_math analog).
+set(LOOPS_HIP_RELEASE_FLAGS
+  -ffast-math
+)
+
 target_compile_options(loops INTERFACE
   $<$<COMPILE_LANGUAGE:CXX>:${LOOPS_HOST_WARNINGS}>
   $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:${LOOPS_CUDA_DEBUG_FLAGS}>
   $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<NOT:$<CONFIG:Debug>>>:${LOOPS_CUDA_RELEASE_FLAGS}>
+  $<$<AND:$<COMPILE_LANGUAGE:HIP>,$<NOT:$<CONFIG:Debug>>>:${LOOPS_HIP_RELEASE_FLAGS}>
 )
 
-# Examples / tests / benchmarks need separable compilation + propagation of
-# CUDA_ARCHITECTURES from the global default. Set them via a helper so callers
-# don't have to repeat the boilerplate.
+# Examples / tests / benchmarks need separable compilation + propagation of the
+# arch list from the global default. A single helper sets the per-backend target
+# properties so callers don't repeat the boilerplate; on HIP it also compiles
+# the shared `.cu` sources as HIP (they are vendor-neutral through loops::xpu).
 function(loops_setup_cuda_target target)
-  set_target_properties(${target} PROPERTIES
-    CXX_STANDARD              17
-    CXX_STANDARD_REQUIRED     ON
-    CXX_EXTENSIONS            OFF
-    CUDA_STANDARD             17
-    CUDA_STANDARD_REQUIRED    ON
-    CUDA_EXTENSIONS           OFF
-    CUDA_SEPARABLE_COMPILATION ON
-    CUDA_RESOLVE_DEVICE_SYMBOLS ON
-  )
+  if(LOOPS_BACKEND STREQUAL "HIP")
+    get_target_property(_loops_srcs ${target} SOURCES)
+    foreach(_src IN LISTS _loops_srcs)
+      if(_src MATCHES "\\.cu$")
+        set_source_files_properties(${_src} PROPERTIES LANGUAGE HIP)
+      endif()
+    endforeach()
+    set_target_properties(${target} PROPERTIES
+      CXX_STANDARD              17
+      CXX_STANDARD_REQUIRED     ON
+      CXX_EXTENSIONS            OFF
+      HIP_STANDARD              17
+      HIP_STANDARD_REQUIRED     ON
+      HIP_ARCHITECTURES         "${CMAKE_HIP_ARCHITECTURES}"
+    )
+  else()
+    set_target_properties(${target} PROPERTIES
+      CXX_STANDARD              17
+      CXX_STANDARD_REQUIRED     ON
+      CXX_EXTENSIONS            OFF
+      CUDA_STANDARD             17
+      CUDA_STANDARD_REQUIRED    ON
+      CUDA_EXTENSIONS           OFF
+      CUDA_SEPARABLE_COMPILATION ON
+      CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    )
+  endif()
 endfunction()
 
 # ----- Subdirectories -----------------------------------------------------

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -80,6 +80,39 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CUDA_ARCHITECTURES": "80;90"
       }
+    },
+    {
+      "name": "hip-base",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "LOOPS_BACKEND": "HIP"
+      }
+    },
+    {
+      "name": "release-mi210",
+      "displayName": "Release / gfx90a only (MI210 / MI250, CDNA2)",
+      "inherits": "hip-base",
+      "cacheVariables": {
+        "CMAKE_HIP_ARCHITECTURES": "gfx90a"
+      }
+    },
+    {
+      "name": "release-mi300x",
+      "displayName": "Release / gfx942 only (MI300X / MI300A / MI325X, CDNA3)",
+      "inherits": "hip-base",
+      "cacheVariables": {
+        "CMAKE_HIP_ARCHITECTURES": "gfx942"
+      }
+    },
+    {
+      "name": "release-mi350x",
+      "displayName": "Release / gfx950 only (MI350X, CDNA4)",
+      "inherits": "hip-base",
+      "cacheVariables": {
+        "CMAKE_HIP_ARCHITECTURES": "gfx950"
+      }
     }
   ],
   "buildPresets": [
@@ -118,6 +151,21 @@
       "configurePreset": "ci-multi-arch",
       "description": "Parallelism capped at 2: hosted CI runners (~16 GB) OOM if every Thrust/CUB-heavy nvcc/cicc runs at once across the f32/f64 x multi-arch target set.",
       "jobs": 2
+    },
+    {
+      "name": "release-mi210",
+      "configurePreset": "release-mi210",
+      "jobs": 0
+    },
+    {
+      "name": "release-mi300x",
+      "configurePreset": "release-mi300x",
+      "jobs": 0
+    },
+    {
+      "name": "release-mi350x",
+      "configurePreset": "release-mi350x",
+      "jobs": 0
     }
   ],
   "testPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -113,6 +113,14 @@
       "cacheVariables": {
         "CMAKE_HIP_ARCHITECTURES": "gfx950"
       }
+    },
+    {
+      "name": "release-rx9070",
+      "displayName": "Release / gfx1201 only (Radeon RX 9070 XT, RDNA4)",
+      "inherits": "hip-base",
+      "cacheVariables": {
+        "CMAKE_HIP_ARCHITECTURES": "gfx1201"
+      }
     }
   ],
   "buildPresets": [
@@ -165,6 +173,11 @@
     {
       "name": "release-mi350x",
       "configurePreset": "release-mi350x",
+      "jobs": 0
+    },
+    {
+      "name": "release-rx9070",
+      "configurePreset": "release-rx9070",
       "jobs": 0
     }
   ],

--- a/examples/spmv/CMakeLists.txt
+++ b/examples/spmv/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(LOOPS_SPMV_SOURCES
   original.cu
   thread_mapped.cu
-  group_mapped.cu
   work_oriented.cu
   merge_path.cu
   ell_thread_mapped.cu
@@ -13,6 +12,13 @@ set(LOOPS_SPMV_SOURCES
   bcsr_thread_mapped.cu
   dia_thread_mapped.cu
 )
+
+# group_mapped leans on NVIDIA cooperative-groups (experimental
+# block_tile_memory + exclusive_scan), which HIP does not provide yet, so it is
+# a CUDA-only example.
+if(NOT LOOPS_BACKEND STREQUAL "HIP")
+  list(APPEND LOOPS_SPMV_SOURCES group_mapped.cu)
+endif()
 
 # Each SpMV example compiles for two precisions:
 #   - <name>.f32  (LOOPS_VALUE_T=float)

--- a/examples/spmv/custom_layout.cu
+++ b/examples/spmv/custom_layout.cu
@@ -232,7 +232,7 @@ int main(int argc, char** argv) {
                           thrust::raw_pointer_cast(storage.indices.data()),
                           thrust::raw_pointer_cast(storage.values.data()),
                           x.data().get(), y.data().get());
-  cudaStreamSynchronize(0);
+  xpu::stream_synchronize(0);
   timer.stop();
 
   std::cout << "custom_layout," << mtx.dataset << "," << csr.rows << ","

--- a/include/loops/algorithms/spmm/thread_mapped.cuh
+++ b/include/loops/algorithms/spmm/thread_mapped.cuh
@@ -68,7 +68,7 @@ template <typename index_t, typename offset_t, typename type_t>
 void thread_mapped(csr_t<index_t, offset_t, type_t>& csr,
                    matrix_t<type_t>& B,
                    matrix_t<type_t>& C,
-                   cudaStream_t stream = 0) {
+                   xpu::stream_t stream = 0) {
   // Create a schedule.
   constexpr std::size_t block_size = 128;
 
@@ -86,7 +86,7 @@ void thread_mapped(csr_t<index_t, offset_t, type_t>& csr,
       csr.offsets.data().get(), csr.indices.data().get(),
       csr.values.data().get(), B, C);
 
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
 }
 
 }  // namespace spmm

--- a/include/loops/algorithms/spmv/bcsr_thread_mapped.cuh
+++ b/include/loops/algorithms/spmv/bcsr_thread_mapped.cuh
@@ -93,7 +93,7 @@ template <std::size_t R,
 util::timer_t bcsr_thread_mapped(bcsr_t<R, C, index_t, offset_t, type_t>& bcsr,
                                  vector_t<type_t>& x,
                                  vector_t<type_t>& y,
-                                 cudaStream_t stream = 0) {
+                                 xpu::stream_t stream = 0) {
   using tile_id_t = index_t;
   using atom_id_t = offset_t;
   using bcsr_layout_t = layout::bcsr<tile_id_t, atom_id_t>;
@@ -117,7 +117,7 @@ util::timer_t bcsr_thread_mapped(bcsr_t<R, C, index_t, offset_t, type_t>& bcsr,
       stream, __bcsr_thread_mapped<R, C, setup_t, index_t, type_t>, grid_size,
       block_size, config, bcsr.rows, bcsr.block_col_indices.data().get(),
       bcsr.values.data().get(), x.data().get(), y.data().get());
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
   timer.stop();
   return timer;
 }

--- a/include/loops/algorithms/spmv/coo_thread_mapped.cuh
+++ b/include/loops/algorithms/spmv/coo_thread_mapped.cuh
@@ -60,7 +60,7 @@ template <typename index_t, typename type_t>
 util::timer_t coo_thread_mapped(coo_t<index_t, type_t>& coo,
                                 vector_t<type_t>& x,
                                 vector_t<type_t>& y,
-                                cudaStream_t stream = 0) {
+                                xpu::stream_t stream = 0) {
   using tile_id_t = index_t;
   using atom_id_t = index_t;
   using coo_layout_t = layout::coo<tile_id_t, atom_id_t>;
@@ -83,7 +83,7 @@ util::timer_t coo_thread_mapped(coo_t<index_t, type_t>& coo,
                           coo.row_indices.data().get(),
                           coo.col_indices.data().get(), coo.values.data().get(),
                           x.data().get(), y.data().get());
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
   timer.stop();
   return timer;
 }

--- a/include/loops/algorithms/spmv/csc_thread_mapped.cuh
+++ b/include/loops/algorithms/spmv/csc_thread_mapped.cuh
@@ -59,7 +59,7 @@ template <typename index_t, typename offset_t, typename type_t>
 util::timer_t csc_thread_mapped(csc_t<index_t, offset_t, type_t>& csc,
                                 vector_t<type_t>& x,
                                 vector_t<type_t>& y,
-                                cudaStream_t stream = 0) {
+                                xpu::stream_t stream = 0) {
   using tile_id_t = index_t;
   using atom_id_t = offset_t;
   using csc_layout_t = layout::csc<tile_id_t, atom_id_t>;
@@ -82,7 +82,7 @@ util::timer_t csc_thread_mapped(csc_t<index_t, offset_t, type_t>& csc,
                           grid_size, block_size, config,
                           csc.indices.data().get(), csc.values.data().get(),
                           x.data().get(), y.data().get());
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
   timer.stop();
   return timer;
 }

--- a/include/loops/algorithms/spmv/dia_thread_mapped.cuh
+++ b/include/loops/algorithms/spmv/dia_thread_mapped.cuh
@@ -67,7 +67,7 @@ template <typename index_t, typename offset_t, typename type_t>
 util::timer_t dia_thread_mapped(dia_t<index_t, offset_t, type_t>& dia,
                                 vector_t<type_t>& x,
                                 vector_t<type_t>& y,
-                                cudaStream_t stream = 0) {
+                                xpu::stream_t stream = 0) {
   using tile_id_t = std::size_t;
   using atom_id_t = std::size_t;
   using dia_layout_t = layout::dia<tile_id_t, atom_id_t>;
@@ -91,7 +91,7 @@ util::timer_t dia_thread_mapped(dia_t<index_t, offset_t, type_t>& dia,
                           dia.num_diagonals, dia.diag_offsets.data().get(),
                           dia.values.data().get(), x.data().get(),
                           y.data().get());
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
   timer.stop();
   return timer;
 }

--- a/include/loops/algorithms/spmv/ell_merge_path.cuh
+++ b/include/loops/algorithms/spmv/ell_merge_path.cuh
@@ -77,7 +77,7 @@ template <typename index_t, typename type_t>
 util::timer_t ell_merge_path(ell_t<index_t, type_t>& ell,
                              vector_t<type_t>& x,
                              vector_t<type_t>& y,
-                             cudaStream_t stream = 0) {
+                             xpu::stream_t stream = 0) {
   using tile_id_t = index_t;
   using atom_id_t = index_t;
   using ell_layout_t = layout::ell<tile_id_t, atom_id_t>;
@@ -102,7 +102,8 @@ util::timer_t ell_merge_path(ell_t<index_t, type_t>& ell,
   int num_merge_tiles = math::ceil_div(ell.rows + ell.rows * ell.pitch,
                                        block_size * items_per_thread);
   int device_ordinal = device::get();
-  cudaDeviceGetAttribute(&max_dim_x, cudaDevAttrMaxGridDimX, device_ordinal);
+  xpu::device_get_attribute(&max_dim_x, xpu::attr_max_grid_dim_x,
+                            device_ordinal);
 
   util::timer_t timer;
   timer.start();
@@ -120,7 +121,7 @@ util::timer_t ell_merge_path(ell_t<index_t, type_t>& ell,
                        ell_layout_t, index_t, type_t>,
       grid_size, block_size, meta, lay, ell.indices.data().get(),
       ell.values.data().get(), x.data().get(), y.data().get());
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
   timer.stop();
 
   return timer;

--- a/include/loops/algorithms/spmv/ell_merge_path.cuh
+++ b/include/loops/algorithms/spmv/ell_merge_path.cuh
@@ -25,8 +25,6 @@
 #include <loops/util/timer.hxx>
 #include <loops/memory.hxx>
 
-#include <cub/block/block_scan.cuh>
-
 namespace loops {
 namespace algorithms {
 namespace spmv {

--- a/include/loops/algorithms/spmv/ell_thread_mapped.cuh
+++ b/include/loops/algorithms/spmv/ell_thread_mapped.cuh
@@ -53,7 +53,7 @@ template <typename index_t, typename type_t>
 void ell_thread_mapped(ell_t<index_t, type_t>& ell,
                        vector_t<type_t>& x,
                        vector_t<type_t>& y,
-                       cudaStream_t stream = 0) {
+                       xpu::stream_t stream = 0) {
   using tile_id_t = index_t;
   using atom_id_t = index_t;
   using ell_layout_t = layout::ell<tile_id_t, atom_id_t>;
@@ -72,7 +72,7 @@ void ell_thread_mapped(ell_t<index_t, type_t>& ell,
                           ell.indices.data().get(), ell.values.data().get(),
                           x.data().get(), y.data().get());
 
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
 }
 
 }  // namespace spmv

--- a/include/loops/algorithms/spmv/flat_partitioned.cuh
+++ b/include/loops/algorithms/spmv/flat_partitioned.cuh
@@ -74,7 +74,7 @@ template <std::size_t K = 8,
 util::timer_t flat_partitioned(csr_t<index_t, offset_t, type_t>& csr,
                                vector_t<type_t>& x,
                                vector_t<type_t>& y,
-                               cudaStream_t stream = 0) {
+                               xpu::stream_t stream = 0) {
   using tile_id_t = index_t;
   using atom_id_t = offset_t;
   using base_layout_t = layout::csr<tile_id_t, atom_id_t>;
@@ -101,7 +101,7 @@ util::timer_t flat_partitioned(csr_t<index_t, offset_t, type_t>& csr,
                           grid_size, block_size, config,
                           csr.indices.data().get(), csr.values.data().get(),
                           x.data().get(), y.data().get());
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
   timer.stop();
   return timer;
 }

--- a/include/loops/algorithms/spmv/group_mapped.cuh
+++ b/include/loops/algorithms/spmv/group_mapped.cuh
@@ -75,7 +75,7 @@ template <typename index_t, typename offset_t, typename type_t>
 void group_mapped(csr_t<index_t, offset_t, type_t>& csr,
                   vector_t<type_t>& x,
                   vector_t<type_t>& y,
-                  cudaStream_t stream = 0) {
+                  xpu::stream_t stream = 0) {
   constexpr std::size_t block_size = launch_t<type_t>::block_size;
 
   /// Set-up kernel launch parameters and run the kernel.
@@ -101,7 +101,7 @@ void group_mapped(csr_t<index_t, offset_t, type_t>& csr,
   //                     csr.values.data().get(), x.data().get(),
   //                     y.data().get());
 
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
 }
 
 }  // namespace spmv

--- a/include/loops/algorithms/spmv/launch_box.hxx
+++ b/include/loops/algorithms/spmv/launch_box.hxx
@@ -38,21 +38,25 @@ namespace spmv {
  * @par AMD CDNA (wavefront = 64, Instinct)
  * 256 threads/block = 4 wavefronts: the wavefront is the 64-wide reduction and
  * scheduling unit (the warp analog), so block sizes and reduction granularity
- * are multiples of 64 rather than 32. gfx90a (MI210/MI250, CDNA2) has an 8 MB
- * L2 and no last-level cache, so it takes the narrower floor tile; gfx942
- * (MI300/MI325, CDNA3) and gfx950 (MI350, CDNA4) add a large Infinity Cache
- * (LLC) that keeps @c x hot, so they widen the tile like Hopper. gfx906/gfx908
- * (MI50/MI100) reuse the CDNA floor. LDS is 64 KB/CU across CDNA, comfortably
- * covering the per-block merge-path buffer at these sizes.
+ * are multiples of 64, not 32. gfx90a (MI210/MI250, CDNA2) has a 16 KB/CU L1,
+ * 8 MB L2, and *no* last-level cache, so @c x falls back to HBM and it takes
+ * the narrower floor tile; gfx942 (MI300X/MI325X, CDNA3) and gfx950 (MI350X,
+ * CDNA4) add a 32 KB L1 and a 256 MB Infinity Cache (MALL) that keeps @c x hot
+ * across atoms, so they widen the tile like Hopper. gfx906/gfx908 (MI50/MI100)
+ * reuse the CDNA floor. LDS is 64 KB/CU on gfx90a/gfx942 (160 KB on gfx950),
+ * all of which cover the per-block merge-path buffer at these sizes. (CDNA2/3/4
+ * whitepapers + ROCm gpu-arch-specs.)
  *
  * @par AMD RDNA (native wave32, Radeon)
- * 256 threads/block over the native 32-wide wavefront; RDNA pairs CUs into a
- * WGP and carries a large Infinity Cache, so it takes the wide tile. Set
- * analytically -- not yet validated on Radeon hardware.
+ * 256 threads/block; RDNA's native wavefront is 32 (the warp analog) and pairs
+ * 2 CUs into a WGP, and every RDNA part carries a large Infinity Cache, so it
+ * takes the wide tile. gfx1030 RDNA2, gfx1100 RDNA3, gfx1200/gfx1201 RDNA4.
+ * Analytically set -- not yet validated on Radeon hardware.
  *
  * @note The CDNA/RDNA tiles are reasoned from the ISA/architecture references
  * (wavefront width, LDS, cache hierarchy), not autotuned; treat them as solid
- * starting points rather than per-matrix optima.
+ * starting points rather than per-matrix optima. Validated on gfx90a (MI210)
+ * and gfx942 (MI300X) under ROCm 7.2; gfx950/RDNA are analytical.
  *
  * @tparam type_t Value type; selects the 4- vs 8-byte items-per-thread.
  */
@@ -78,7 +82,7 @@ using launch_t = launch_box::launch_box_t<
                                 (sizeof(type_t) > 4 ? 4 : 7)>,
     // AMD RDNA (analytically set; wave32 + Infinity Cache).
     launch_box::launch_params_t<launch_box::gfx1030 | launch_box::gfx1100 |
-                                    launch_box::gfx1200,
+                                    launch_box::gfx1200 | launch_box::gfx1201,
                                 256,
                                 (sizeof(type_t) > 4 ? 4 : 8)>,
     launch_box::launch_params_t<launch_box::fallback,

--- a/include/loops/algorithms/spmv/launch_box.hxx
+++ b/include/loops/algorithms/spmv/launch_box.hxx
@@ -22,17 +22,43 @@ namespace spmv {
 /**
  * @brief SpMV launch configuration for the architecture being compiled for.
  *
- * SpMV is bandwidth-bound (~2 flop/nonzero), so 128 threads/block (4 warps)
- * gives enough warps to hide DRAM latency while keeping block occupancy
- * granular. @c items_per_thread sets the merge/work-tile granularity: 8-byte
- * values halve it (each atom moves twice the bytes), and Hopper/Blackwell widen
- * it because their larger L2 keeps @c x resident across more atoms, so a wider
- * tile amortizes the per-thread search. Ampere is the fallback floor.
+ * SpMV is bandwidth-bound (~2 flop/nonzero), so the block size is picked to be
+ * a few scheduler-width units -- enough resident warps/wavefronts to hide DRAM
+ * latency while keeping block occupancy granular -- and @c items_per_thread
+ * sets the merge/work-tile granularity. 8-byte values halve the item count
+ * (each atom moves twice the bytes); architectures with a larger last-level
+ * cache widen it, since @c x stays resident across more atoms and a wider tile
+ * amortizes the per-thread diagonal search.
+ *
+ * @par NVIDIA (warp = 32)
+ * 128 threads/block = 4 warps. Hopper/Blackwell (sm_90/sm_100) widen the tile
+ * over their larger L2; Ampere-and-below is the floor, and @c fallback catches
+ * multi-arch / native CUDA builds.
+ *
+ * @par AMD CDNA (wavefront = 64, Instinct)
+ * 256 threads/block = 4 wavefronts: the wavefront is the 64-wide reduction and
+ * scheduling unit (the warp analog), so block sizes and reduction granularity
+ * are multiples of 64 rather than 32. gfx90a (MI210/MI250, CDNA2) has an 8 MB
+ * L2 and no last-level cache, so it takes the narrower floor tile; gfx942
+ * (MI300/MI325, CDNA3) and gfx950 (MI350, CDNA4) add a large Infinity Cache
+ * (LLC) that keeps @c x hot, so they widen the tile like Hopper. gfx906/gfx908
+ * (MI50/MI100) reuse the CDNA floor. LDS is 64 KB/CU across CDNA, comfortably
+ * covering the per-block merge-path buffer at these sizes.
+ *
+ * @par AMD RDNA (native wave32, Radeon)
+ * 256 threads/block over the native 32-wide wavefront; RDNA pairs CUs into a
+ * WGP and carries a large Infinity Cache, so it takes the wide tile. Set
+ * analytically -- not yet validated on Radeon hardware.
+ *
+ * @note The CDNA/RDNA tiles are reasoned from the ISA/architecture references
+ * (wavefront width, LDS, cache hierarchy), not autotuned; treat them as solid
+ * starting points rather than per-matrix optima.
  *
  * @tparam type_t Value type; selects the 4- vs 8-byte items-per-thread.
  */
 template <typename type_t>
 using launch_t = launch_box::launch_box_t<
+    // NVIDIA.
     launch_box::launch_params_t<launch_box::sm_90 | launch_box::sm_100,
                                 128,
                                 (sizeof(type_t) > 4 ? 4 : 8)>,
@@ -41,6 +67,20 @@ using launch_t = launch_box::launch_box_t<
                                     launch_box::sm_89,
                                 128,
                                 (sizeof(type_t) > 4 ? 4 : 7)>,
+    // AMD CDNA: large-LLC parts (gfx942/gfx950) widen the tile.
+    launch_box::launch_params_t<launch_box::gfx942 | launch_box::gfx950,
+                                256,
+                                (sizeof(type_t) > 4 ? 4 : 8)>,
+    // AMD CDNA floor (gfx90a + older): 8 MB L2, no last-level cache.
+    launch_box::launch_params_t<launch_box::gfx906 | launch_box::gfx908 |
+                                    launch_box::gfx90a,
+                                256,
+                                (sizeof(type_t) > 4 ? 4 : 7)>,
+    // AMD RDNA (analytically set; wave32 + Infinity Cache).
+    launch_box::launch_params_t<launch_box::gfx1030 | launch_box::gfx1100 |
+                                    launch_box::gfx1200,
+                                256,
+                                (sizeof(type_t) > 4 ? 4 : 8)>,
     launch_box::launch_params_t<launch_box::fallback,
                                 128,
                                 (sizeof(type_t) > 4 ? 4 : 7)>>;

--- a/include/loops/algorithms/spmv/merge_path_flat.cuh
+++ b/include/loops/algorithms/spmv/merge_path_flat.cuh
@@ -22,8 +22,6 @@
 #include <loops/memory.hxx>
 #include <iostream>
 
-#include <cub/block/block_scan.cuh>
-
 namespace loops {
 namespace algorithms {
 namespace spmv {

--- a/include/loops/algorithms/spmv/merge_path_flat.cuh
+++ b/include/loops/algorithms/spmv/merge_path_flat.cuh
@@ -99,7 +99,7 @@ template <typename index_t, typename offset_t, typename type_t>
 util::timer_t merge_path_flat(csr_t<index_t, offset_t, type_t>& csr,
                               vector_t<type_t>& x,
                               vector_t<type_t>& y,
-                              cudaStream_t stream = 0) {
+                              xpu::stream_t stream = 0) {
   constexpr std::size_t block_size = launch_t<type_t>::block_size;
   constexpr std::size_t items_per_thread = launch_t<type_t>::items_per_thread;
 
@@ -117,7 +117,8 @@ util::timer_t merge_path_flat(csr_t<index_t, offset_t, type_t>& csr,
   int num_merge_tiles =
       math::ceil_div(csr.rows + csr.nnzs, block_size * items_per_thread);
   int device_ordinal = device::get();
-  cudaDeviceGetAttribute(&max_dim_x, cudaDevAttrMaxGridDimX, device_ordinal);
+  xpu::device_get_attribute(&max_dim_x, xpu::attr_max_grid_dim_x,
+                            device_ordinal);
 
   util::timer_t timer;
   timer.start();
@@ -133,7 +134,7 @@ util::timer_t merge_path_flat(csr_t<index_t, offset_t, type_t>& csr,
       grid_size, block_size, meta, csr.rows, csr.cols, csr.nnzs,
       csr.offsets.data().get(), csr.indices.data().get(),
       csr.values.data().get(), x.data().get(), y.data().get());
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
   timer.stop();
 
   return timer;

--- a/include/loops/algorithms/spmv/original.cuh
+++ b/include/loops/algorithms/spmv/original.cuh
@@ -60,7 +60,7 @@ template <typename index_t, typename offset_t, typename type_t>
 void original(csr_t<index_t, offset_t, type_t>& csr,
               vector_t<type_t>& x,
               vector_t<type_t>& y,
-              cudaStream_t stream = 0) {
+              xpu::stream_t stream = 0) {
   // Create a schedule.
   constexpr std::size_t block_size = 128;
 
@@ -72,7 +72,7 @@ void original(csr_t<index_t, offset_t, type_t>& csr,
                           csr.values.data().get(), x.data().get(),
                           y.data().get());
 
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
 }
 
 }  // namespace spmv

--- a/include/loops/algorithms/spmv/thread_mapped.cuh
+++ b/include/loops/algorithms/spmv/thread_mapped.cuh
@@ -70,7 +70,7 @@ template <typename index_t, typename offset_t, typename type_t>
 void thread_mapped(csr_t<index_t, offset_t, type_t>& csr,
                    vector_t<type_t>& x,
                    vector_t<type_t>& y,
-                   cudaStream_t stream = 0) {
+                   xpu::stream_t stream = 0) {
   constexpr std::size_t block_size = launch_t<type_t>::block_size;
 
   /// Set-up kernel launch parameters and run the kernel.
@@ -87,7 +87,7 @@ void thread_mapped(csr_t<index_t, offset_t, type_t>& csr,
       csr.offsets.data().get(), csr.indices.data().get(),
       csr.values.data().get(), x.data().get(), y.data().get());
 
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
 }
 
 }  // namespace spmv

--- a/include/loops/algorithms/spmv/work_oriented.cuh
+++ b/include/loops/algorithms/spmv/work_oriented.cuh
@@ -52,13 +52,23 @@ __global__ void __launch_bounds__(threads_per_block)
   setup_t config(offsets, rows, nnz);
   auto map = config.init();
 
-  /// Accumulate the complete tiles.
+  /// Accumulate the complete tiles. A thread's first row may continue a row
+  /// that opens in the previous partition, whose head is emitted there as a
+  /// remainder atomic, so fold the first row in atomically as well; rows that
+  /// fall wholly within this partition are owned outright and written directly.
   type_t sum = 0;
+  bool first_tile = true;
   for (auto row : config.tiles(map)) {
     for (auto nz : config.atoms(row, map)) {
       sum += values[nz] * x[indices[nz]];
     }
-    y[row] = sum;
+    if (first_tile) {
+      if (sum != 0)
+        atomicAdd(&(y[row]), sum);
+      first_tile = false;
+    } else {
+      y[row] = sum;
+    }
     sum = 0;
   }
 

--- a/include/loops/algorithms/spmv/work_oriented.cuh
+++ b/include/loops/algorithms/spmv/work_oriented.cuh
@@ -93,7 +93,7 @@ template <typename index_t, typename offset_t, typename type_t>
 void work_oriented(csr_t<index_t, offset_t, type_t>& csr,
                    vector_t<type_t>& x,
                    vector_t<type_t>& y,
-                   cudaStream_t stream = 0) {
+                   xpu::stream_t stream = 0) {
   constexpr std::size_t block_size = launch_t<type_t>::block_size;
 
   /// Each thread strides over an even share of the (rows + nnz) work, so one
@@ -107,7 +107,7 @@ void work_oriented(csr_t<index_t, offset_t, type_t>& csr,
                           csr.indices.data().get(), csr.values.data().get(),
                           x.data().get(), y.data().get());
 
-  cudaStreamSynchronize(stream);
+  xpu::stream_synchronize(stream);
 }
 
 }  // namespace spmv

--- a/include/loops/backend/cuda.hxx
+++ b/include/loops/backend/cuda.hxx
@@ -1,21 +1,13 @@
 /**
- * @file xpu.hxx
+ * @file cuda.hxx
  * @author Muhammad Osama (mosama@ucdavis.edu)
- * @brief Vendor-neutral device runtime surface (CUDA or HIP).
+ * @brief CUDA implementation of the @c loops::xpu device-runtime surface.
  * @version 0.1
- * @date 2026-06-23
+ * @date 2026-06-24
  *
- * Everything in loops talks to the device runtime through @c loops::xpu so the
- * rest of the tree is not CUDA-specific: a CUDA build (nvcc) and a HIP build
- * (hipcc, AMD ROCm) differ only inside this header. The two runtimes are nearly
- * 1:1 -- @c cudaStreamSynchronize maps to @c hipStreamSynchronize ,
- * @c cudaDeviceProp to @c hipDeviceProp_t -- so the shim stays thin: type
- * aliases plus a token-pasted wrapper per call.
- *
- * Backend selection: CMake sets @c LOOPS_BACKEND_HIP (HIP) or
- * @c LOOPS_BACKEND_CUDA (CUDA, the default). Absent an explicit choice we infer
- * HIP when the AMD compiler defines @c __HIP_PLATFORM_AMD__ , otherwise CUDA, so
- * existing nvcc builds are unaffected.
+ * Selected by @c loops/backend/xpu.hxx on a CUDA build; @c hip.hxx is the
+ * AMD/HIP counterpart. The two mirror each other one call at a time so either
+ * backend can be updated on its own.
  *
  * @copyright Copyright (c) 2026
  *
@@ -25,66 +17,20 @@
 
 #include <cstddef>
 
-#if !defined(LOOPS_BACKEND_HIP) && !defined(LOOPS_BACKEND_CUDA)
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-#define LOOPS_BACKEND_HIP
-#else
-#define LOOPS_BACKEND_CUDA
-#endif
-#endif
-
-#if defined(LOOPS_BACKEND_HIP)
-#include <hip/hip_runtime.h>
-#define LOOPS_XPU_(name) hip##name
-#else
 #include <cuda_runtime.h>
-#define LOOPS_XPU_(name) cuda##name
-#endif
 
 namespace loops {
-
-/**
- * @namespace xpu
- * The device-runtime backend. Names here read as the vendor-neutral verb
- * (@c xpu::stream_synchronize ) and resolve to CUDA or HIP at compile time.
- */
 namespace xpu {
 
 // ----- Types --------------------------------------------------------------
-#if defined(LOOPS_BACKEND_HIP)
-using error_t = hipError_t;
-using stream_t = hipStream_t;
-using event_t = hipEvent_t;
-using device_properties_t = hipDeviceProp_t;
-using memcpy_kind_t = hipMemcpyKind;
-using device_attribute_t = hipDeviceAttribute_t;
-#else
 using error_t = cudaError_t;
 using stream_t = cudaStream_t;
 using event_t = cudaEvent_t;
 using device_properties_t = cudaDeviceProp;
 using memcpy_kind_t = cudaMemcpyKind;
 using device_attribute_t = cudaDeviceAttr;
-#endif
 
 // ----- Constants ----------------------------------------------------------
-#if defined(LOOPS_BACKEND_HIP)
-inline constexpr error_t success = hipSuccess;
-
-inline constexpr memcpy_kind_t memcpy_host_to_device = hipMemcpyHostToDevice;
-inline constexpr memcpy_kind_t memcpy_device_to_host = hipMemcpyDeviceToHost;
-inline constexpr memcpy_kind_t memcpy_device_to_device =
-    hipMemcpyDeviceToDevice;
-
-inline constexpr device_attribute_t attr_multiprocessor_count =
-    hipDeviceAttributeMultiprocessorCount;
-inline constexpr device_attribute_t attr_compute_capability_major =
-    hipDeviceAttributeComputeCapabilityMajor;
-inline constexpr device_attribute_t attr_compute_capability_minor =
-    hipDeviceAttributeComputeCapabilityMinor;
-inline constexpr device_attribute_t attr_max_grid_dim_x =
-    hipDeviceAttributeMaxGridDimX;
-#else
 inline constexpr error_t success = cudaSuccess;
 
 inline constexpr memcpy_kind_t memcpy_host_to_device = cudaMemcpyHostToDevice;
@@ -100,88 +46,87 @@ inline constexpr device_attribute_t attr_compute_capability_minor =
     cudaDevAttrComputeCapabilityMinor;
 inline constexpr device_attribute_t attr_max_grid_dim_x =
     cudaDevAttrMaxGridDimX;
-#endif
 
 // ----- Device management --------------------------------------------------
 inline error_t set_device(int ordinal) {
-  return LOOPS_XPU_(SetDevice)(ordinal);
+  return cudaSetDevice(ordinal);
 }
 
 inline error_t get_device(int* ordinal) {
-  return LOOPS_XPU_(GetDevice)(ordinal);
+  return cudaGetDevice(ordinal);
 }
 
 inline error_t get_device_properties(device_properties_t* props, int ordinal) {
-  return LOOPS_XPU_(GetDeviceProperties)(props, ordinal);
+  return cudaGetDeviceProperties(props, ordinal);
 }
 
 inline error_t device_get_attribute(int* value,
                                     device_attribute_t attr,
                                     int ordinal) {
-  return LOOPS_XPU_(DeviceGetAttribute)(value, attr, ordinal);
+  return cudaDeviceGetAttribute(value, attr, ordinal);
 }
 
 inline error_t device_synchronize() {
-  return LOOPS_XPU_(DeviceSynchronize)();
+  return cudaDeviceSynchronize();
 }
 
 // ----- Memory -------------------------------------------------------------
 inline error_t malloc(void** ptr, std::size_t bytes) {
-  return LOOPS_XPU_(Malloc)(ptr, bytes);
+  return cudaMalloc(ptr, bytes);
 }
 
 inline error_t free(void* ptr) {
-  return LOOPS_XPU_(Free)(ptr);
+  return cudaFree(ptr);
 }
 
 inline error_t memcpy(void* dst,
                       const void* src,
                       std::size_t bytes,
                       memcpy_kind_t kind) {
-  return LOOPS_XPU_(Memcpy)(dst, src, bytes, kind);
+  return cudaMemcpy(dst, src, bytes, kind);
 }
 
 // ----- Streams ------------------------------------------------------------
 inline error_t stream_synchronize(stream_t stream = 0) {
-  return LOOPS_XPU_(StreamSynchronize)(stream);
+  return cudaStreamSynchronize(stream);
 }
 
 // ----- Events -------------------------------------------------------------
 inline error_t event_create(event_t* event) {
-  return LOOPS_XPU_(EventCreate)(event);
+  return cudaEventCreate(event);
 }
 
 inline error_t event_destroy(event_t event) {
-  return LOOPS_XPU_(EventDestroy)(event);
+  return cudaEventDestroy(event);
 }
 
 inline error_t event_record(event_t event, stream_t stream = 0) {
-  return LOOPS_XPU_(EventRecord)(event, stream);
+  return cudaEventRecord(event, stream);
 }
 
 inline error_t event_synchronize(event_t event) {
-  return LOOPS_XPU_(EventSynchronize)(event);
+  return cudaEventSynchronize(event);
 }
 
 inline error_t event_elapsed_time(float* ms, event_t start, event_t stop) {
-  return LOOPS_XPU_(EventElapsedTime)(ms, start, stop);
+  return cudaEventElapsedTime(ms, start, stop);
 }
 
 // ----- Errors -------------------------------------------------------------
 inline const char* get_error_string(error_t status) {
-  return LOOPS_XPU_(GetErrorString)(status);
+  return cudaGetErrorString(status);
 }
 
 // ----- Occupancy ----------------------------------------------------------
-/// Max resident blocks per multiprocessor (SM / CU) for @p kernel; the launch
-/// boxes turn this into a one-wave grid.
+/// Max resident blocks per multiprocessor (SM) for @p kernel; the launch boxes
+/// turn this into a one-wave grid.
 template <typename kernel_t>
 inline error_t occupancy_max_active_blocks_per_multiprocessor(
     int* blocks_per_sm,
     kernel_t kernel,
     int block_size,
     std::size_t dynamic_shared_memory_bytes) {
-  return LOOPS_XPU_(OccupancyMaxActiveBlocksPerMultiprocessor)(
+  return cudaOccupancyMaxActiveBlocksPerMultiprocessor(
       blocks_per_sm, kernel, block_size, dynamic_shared_memory_bytes);
 }
 
@@ -193,7 +138,7 @@ inline error_t launch_cooperative_kernel(const func_t* kernel,
                                          void** args,
                                          std::size_t shared_memory_bytes,
                                          stream_t stream) {
-  return LOOPS_XPU_(LaunchCooperativeKernel)<func_t>(
+  return cudaLaunchCooperativeKernel<func_t>(
       kernel, grid_dim, block_dim, args, shared_memory_bytes, stream);
 }
 

--- a/include/loops/backend/hip.hxx
+++ b/include/loops/backend/hip.hxx
@@ -1,0 +1,146 @@
+/**
+ * @file hip.hxx
+ * @author Muhammad Osama (mosama@ucdavis.edu)
+ * @brief HIP/ROCm implementation of the @c loops::xpu device-runtime surface.
+ * @version 0.1
+ * @date 2026-06-24
+ *
+ * Selected by @c loops/backend/xpu.hxx on a HIP build; @c cuda.hxx is the
+ * NVIDIA counterpart. The two mirror each other one call at a time so either
+ * backend can be updated on its own.
+ *
+ * @copyright Copyright (c) 2026
+ *
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include <hip/hip_runtime.h>
+
+namespace loops {
+namespace xpu {
+
+// ----- Types --------------------------------------------------------------
+using error_t = hipError_t;
+using stream_t = hipStream_t;
+using event_t = hipEvent_t;
+using device_properties_t = hipDeviceProp_t;
+using memcpy_kind_t = hipMemcpyKind;
+using device_attribute_t = hipDeviceAttribute_t;
+
+// ----- Constants ----------------------------------------------------------
+inline constexpr error_t success = hipSuccess;
+
+inline constexpr memcpy_kind_t memcpy_host_to_device = hipMemcpyHostToDevice;
+inline constexpr memcpy_kind_t memcpy_device_to_host = hipMemcpyDeviceToHost;
+inline constexpr memcpy_kind_t memcpy_device_to_device =
+    hipMemcpyDeviceToDevice;
+
+inline constexpr device_attribute_t attr_multiprocessor_count =
+    hipDeviceAttributeMultiprocessorCount;
+inline constexpr device_attribute_t attr_compute_capability_major =
+    hipDeviceAttributeComputeCapabilityMajor;
+inline constexpr device_attribute_t attr_compute_capability_minor =
+    hipDeviceAttributeComputeCapabilityMinor;
+inline constexpr device_attribute_t attr_max_grid_dim_x =
+    hipDeviceAttributeMaxGridDimX;
+
+// ----- Device management --------------------------------------------------
+inline error_t set_device(int ordinal) {
+  return hipSetDevice(ordinal);
+}
+
+inline error_t get_device(int* ordinal) {
+  return hipGetDevice(ordinal);
+}
+
+inline error_t get_device_properties(device_properties_t* props, int ordinal) {
+  return hipGetDeviceProperties(props, ordinal);
+}
+
+inline error_t device_get_attribute(int* value,
+                                    device_attribute_t attr,
+                                    int ordinal) {
+  return hipDeviceGetAttribute(value, attr, ordinal);
+}
+
+inline error_t device_synchronize() {
+  return hipDeviceSynchronize();
+}
+
+// ----- Memory -------------------------------------------------------------
+inline error_t malloc(void** ptr, std::size_t bytes) {
+  return hipMalloc(ptr, bytes);
+}
+
+inline error_t free(void* ptr) {
+  return hipFree(ptr);
+}
+
+inline error_t memcpy(void* dst,
+                      const void* src,
+                      std::size_t bytes,
+                      memcpy_kind_t kind) {
+  return hipMemcpy(dst, src, bytes, kind);
+}
+
+// ----- Streams ------------------------------------------------------------
+inline error_t stream_synchronize(stream_t stream = 0) {
+  return hipStreamSynchronize(stream);
+}
+
+// ----- Events -------------------------------------------------------------
+inline error_t event_create(event_t* event) {
+  return hipEventCreate(event);
+}
+
+inline error_t event_destroy(event_t event) {
+  return hipEventDestroy(event);
+}
+
+inline error_t event_record(event_t event, stream_t stream = 0) {
+  return hipEventRecord(event, stream);
+}
+
+inline error_t event_synchronize(event_t event) {
+  return hipEventSynchronize(event);
+}
+
+inline error_t event_elapsed_time(float* ms, event_t start, event_t stop) {
+  return hipEventElapsedTime(ms, start, stop);
+}
+
+// ----- Errors -------------------------------------------------------------
+inline const char* get_error_string(error_t status) {
+  return hipGetErrorString(status);
+}
+
+// ----- Occupancy ----------------------------------------------------------
+/// Max resident blocks per multiprocessor (CU) for @p kernel; the launch boxes
+/// turn this into a one-wave grid.
+template <typename kernel_t>
+inline error_t occupancy_max_active_blocks_per_multiprocessor(
+    int* blocks_per_sm,
+    kernel_t kernel,
+    int block_size,
+    std::size_t dynamic_shared_memory_bytes) {
+  return hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      blocks_per_sm, kernel, block_size, dynamic_shared_memory_bytes);
+}
+
+// ----- Cooperative launch -------------------------------------------------
+template <typename func_t>
+inline error_t launch_cooperative_kernel(const func_t* kernel,
+                                         dim3 grid_dim,
+                                         dim3 block_dim,
+                                         void** args,
+                                         std::size_t shared_memory_bytes,
+                                         stream_t stream) {
+  return hipLaunchCooperativeKernel<func_t>(
+      kernel, grid_dim, block_dim, args, shared_memory_bytes, stream);
+}
+
+}  // namespace xpu
+}  // namespace loops

--- a/include/loops/backend/xpu.hxx
+++ b/include/loops/backend/xpu.hxx
@@ -1,0 +1,42 @@
+/**
+ * @file xpu.hxx
+ * @author Muhammad Osama (mosama@ucdavis.edu)
+ * @brief Vendor-neutral device runtime surface (CUDA or HIP).
+ * @version 0.1
+ * @date 2026-06-23
+ *
+ * Everything in loops talks to the device runtime through @c loops::xpu so the
+ * rest of the tree is not CUDA-specific. This header only selects a backend;
+ * the surface itself lives in @c backend/cuda.hxx (nvcc, the default) and
+ * @c backend/hip.hxx (hipcc, AMD ROCm), which mirror each other call for call.
+ *
+ * Backend selection: CMake sets @c LOOPS_BACKEND_HIP (HIP) or
+ * @c LOOPS_BACKEND_CUDA (CUDA, the default). Absent an explicit choice we infer
+ * HIP when the AMD compiler defines @c __HIP_PLATFORM_AMD__ , otherwise CUDA, so
+ * existing nvcc builds are unaffected.
+ *
+ * @copyright Copyright (c) 2026
+ *
+ */
+
+#pragma once
+
+#if !defined(LOOPS_BACKEND_HIP) && !defined(LOOPS_BACKEND_CUDA)
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+#define LOOPS_BACKEND_HIP
+#else
+#define LOOPS_BACKEND_CUDA
+#endif
+#endif
+
+#if defined(LOOPS_BACKEND_HIP)
+#include <loops/backend/hip.hxx>
+#else
+#include <loops/backend/cuda.hxx>
+#endif
+
+/**
+ * @namespace loops::xpu
+ * The device-runtime backend. Names read as the vendor-neutral verb
+ * (@c xpu::stream_synchronize ) and resolve to CUDA or HIP at compile time.
+ */

--- a/include/loops/error.hxx
+++ b/include/loops/error.hxx
@@ -2,7 +2,8 @@
 
 #include <exception>
 #include <string>
-#include <cuda_runtime_api.h>
+
+#include <loops/util/xpu.hxx>
 
 namespace loops {
 
@@ -12,7 +13,7 @@ namespace loops {
  */
 namespace error {
 
-typedef cudaError_t error_t;
+typedef xpu::error_t error_t;
 
 /**
  * @brief Exception class for errors in device code.
@@ -22,7 +23,7 @@ struct exception_t : std::exception {
   std::string report;
 
   exception_t(error_t _status, std::string _message = "") {
-    report = cudaGetErrorString(_status) + std::string("\t: ") + _message;
+    report = xpu::get_error_string(_status) + std::string("\t: ") + _message;
   }
 
   exception_t(std::string _message = "") { report = _message; }
@@ -30,13 +31,13 @@ struct exception_t : std::exception {
 };
 
 /**
- * @brief Throw an exception if the given error code is not cudaSuccess.
+ * @brief Throw an exception if the given error code is not a success.
  *
- * @param status error_t error code (equivalent to cudaError_t).
+ * @param status error_t error code (xpu::success on no error).
  * @param message custom message to be appended to the error message.
  */
 inline void throw_if_exception(error_t status, std::string message = "") {
-  if (status != cudaSuccess)
+  if (status != xpu::success)
     throw exception_t(status, message);
 }
 

--- a/include/loops/error.hxx
+++ b/include/loops/error.hxx
@@ -3,7 +3,7 @@
 #include <exception>
 #include <string>
 
-#include <loops/util/xpu.hxx>
+#include <loops/backend/xpu.hxx>
 
 namespace loops {
 

--- a/include/loops/schedule.hxx
+++ b/include/loops/schedule.hxx
@@ -14,6 +14,7 @@
 #include <cstddef>
 
 #include <loops/container/layout.hxx>
+#include <loops/util/xpu.hxx>
 
 namespace loops {
 namespace schedule {
@@ -65,6 +66,11 @@ class setup;
 }  // namespace loops
 
 #include <loops/schedule/thread_mapped.hxx>
+// group_mapped relies on NVIDIA cooperative-groups (experimental
+// block_tile_memory, exclusive_scan); no HIP equivalent yet, so it is
+// CUDA-only. HIP builds skip it (and the matching SpMV example).
+#if !defined(LOOPS_BACKEND_HIP)
 #include <loops/schedule/group_mapped.hxx>
+#endif
 #include <loops/schedule/work_oriented.hxx>
 #include <loops/schedule/merge_path_flat.hxx>

--- a/include/loops/schedule.hxx
+++ b/include/loops/schedule.hxx
@@ -14,7 +14,7 @@
 #include <cstddef>
 
 #include <loops/container/layout.hxx>
-#include <loops/util/xpu.hxx>
+#include <loops/backend/xpu.hxx>
 
 namespace loops {
 namespace schedule {

--- a/include/loops/schedule/merge_path_flat.hxx
+++ b/include/loops/schedule/merge_path_flat.hxx
@@ -111,19 +111,19 @@ class preprocess_t {
   preprocess_t(tiles_iterator_t _tiles,
                tile_size_t _num_tiles,
                atom_size_t _num_atoms,
-               cudaStream_t stream = 0)
+               xpu::stream_t stream = 0)
       : preprocess_t(layout_t(_tiles, _num_tiles, _num_atoms), stream) {}
 
   /// Construct directly from a layout view (any layout type).
-  preprocess_t(layout_t _layout, cudaStream_t stream = 0)
+  preprocess_t(layout_t _layout, xpu::stream_t stream = 0)
       : total_work(_layout.num_tiles() + _layout.num_atoms()),
         num_merge_tiles(
             math::ceil_div(total_work, THREADS_PER_BLOCK * ITEMS_PER_THREAD)),
         d_tile_coordinates(nullptr) {
     int sm_count;
     int device_ordinal = device::get();
-    cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount,
-                           device_ordinal);
+    xpu::device_get_attribute(&sm_count, xpu::attr_multiprocessor_count,
+                              device_ordinal);
 
     constexpr std::size_t block_size = THREADS_PER_BLOCK;
     dim3 grid_size = math::ceil_div(num_merge_tiles + 1, block_size);

--- a/include/loops/util/device.hxx
+++ b/include/loops/util/device.hxx
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <loops/util/xpu.hxx>
+#include <loops/backend/xpu.hxx>
 
 namespace loops {
 namespace device {

--- a/include/loops/util/device.hxx
+++ b/include/loops/util/device.hxx
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <loops/util/xpu.hxx>
+
 namespace loops {
 namespace device {
 typedef int device_id_t;
@@ -21,7 +23,7 @@ typedef int device_id_t;
  * @param ordinal device id.
  */
 void set(device_id_t ordinal) {
-  cudaSetDevice(ordinal);
+  xpu::set_device(ordinal);
 }
 
 /**
@@ -31,32 +33,33 @@ void set(device_id_t ordinal) {
  */
 device_id_t get() {
   device_id_t ordinal;
-  cudaGetDevice(&ordinal);
+  xpu::get_device(&ordinal);
   return ordinal;
 }
 
 namespace detail {
 /**
- * @brief Memoized @c cudaGetDeviceProperties, one query per (process, device).
+ * @brief Memoized device-properties query, one per (process, device).
  *
- * @c cudaGetDeviceProperties is a ~1 ms driver call, heavy enough to dominate
+ * The properties query is a ~1 ms driver call, heavy enough to dominate
  * small-matrix runtime if hit on a timed launch path. Caching the
- * @c cudaDeviceProp per ordinal lets callers pay the driver cost once.
- * Host-only and assumes the single-threaded launch path the schedules use.
+ * @c xpu::device_properties_t per ordinal lets callers pay the driver cost
+ * once. Host-only and assumes the single-threaded launch path the schedules
+ * use.
  */
-inline const cudaDeviceProp& cached_properties(device_id_t ordinal) {
+inline const xpu::device_properties_t& cached_properties(device_id_t ordinal) {
   constexpr int max_devices = 16;
-  static cudaDeviceProp cache[max_devices];
+  static xpu::device_properties_t cache[max_devices];
   static bool valid[max_devices] = {};
   if (ordinal >= 0 && ordinal < max_devices) {
     if (!valid[ordinal]) {
-      cudaGetDeviceProperties(&cache[ordinal], ordinal);
+      xpu::get_device_properties(&cache[ordinal], ordinal);
       valid[ordinal] = true;
     }
     return cache[ordinal];
   }
-  static cudaDeviceProp fallback;
-  cudaGetDeviceProperties(&fallback, ordinal);
+  static xpu::device_properties_t fallback;
+  xpu::get_device_properties(&fallback, ordinal);
   return fallback;
 }
 }  // namespace detail
@@ -68,7 +71,7 @@ inline const cudaDeviceProp& cached_properties(device_id_t ordinal) {
  * constructing one is a cheap copy rather than a driver round-trip.
  */
 struct properties_t {
-  typedef cudaDeviceProp device_properties_t;
+  typedef xpu::device_properties_t device_properties_t;
   device_properties_t properties;
   device_id_t ordinal;
 
@@ -80,12 +83,12 @@ struct properties_t {
 };
 
 /**
- * @brief SM (processor) count, memoized.
+ * @brief Multiprocessor (SM on NVIDIA, CU on AMD) count, memoized.
  *
- * Uses @c cudaDeviceGetAttribute (one value, ~microseconds), keeping the launch
- * path clear of the ~1 ms @c cudaGetDeviceProperties query -- including the
- * first, un-warmed call that a single-shot timed launch cannot hide behind a
- * struct cache.
+ * Uses @c xpu::device_get_attribute (one value, ~microseconds), keeping the
+ * launch path clear of the ~1 ms properties query -- including the first,
+ * un-warmed call that a single-shot timed launch cannot hide behind a struct
+ * cache.
  */
 inline int multi_processor_count(device_id_t ordinal = device::get()) {
   constexpr int max_devices = 16;
@@ -93,18 +96,21 @@ inline int multi_processor_count(device_id_t ordinal = device::get()) {
   static bool valid[max_devices] = {};
   if (ordinal < 0 || ordinal >= max_devices) {
     int value = 0;
-    cudaDeviceGetAttribute(&value, cudaDevAttrMultiProcessorCount, ordinal);
+    xpu::device_get_attribute(&value, xpu::attr_multiprocessor_count, ordinal);
     return value;
   }
   if (!valid[ordinal]) {
-    cudaDeviceGetAttribute(&cache[ordinal], cudaDevAttrMultiProcessorCount,
-                           ordinal);
+    xpu::device_get_attribute(&cache[ordinal], xpu::attr_multiprocessor_count,
+                              ordinal);
     valid[ordinal] = true;
   }
   return cache[ordinal];
 }
 
 /// Compute capability flattened to @c major*10+minor (sm_80 -> 80), memoized.
+/// On AMD the runtime reports the CDNA/RDNA major.minor here; kernel tuning
+/// keys off the compile-time @c LOOPS_TARGET_* instead, so this stays a
+/// diagnostic-only value there.
 inline int compute_capability(device_id_t ordinal = device::get()) {
   constexpr int max_devices = 16;
   static int cache[max_devices];
@@ -112,8 +118,10 @@ inline int compute_capability(device_id_t ordinal = device::get()) {
   if (ordinal >= 0 && ordinal < max_devices && valid[ordinal])
     return cache[ordinal];
   int major = 0, minor = 0;
-  cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, ordinal);
-  cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, ordinal);
+  xpu::device_get_attribute(&major, xpu::attr_compute_capability_major,
+                            ordinal);
+  xpu::device_get_attribute(&minor, xpu::attr_compute_capability_minor,
+                            ordinal);
   const int value = major * 10 + minor;
   if (ordinal >= 0 && ordinal < max_devices) {
     cache[ordinal] = value;

--- a/include/loops/util/equal.hxx
+++ b/include/loops/util/equal.hxx
@@ -16,6 +16,10 @@
 #include <iomanip>
 #include <limits>
 
+#include <loops/util/xpu.hxx>
+
+#include <thrust/host_vector.h>
+
 namespace loops {
 namespace util {
 
@@ -45,7 +49,8 @@ std::size_t equal(const type_t* d_ptr,
                   comp_t error_op = detail::default_comparator,
                   const bool verbose = false) {
   thrust::host_vector<type_t> d_vec(n);
-  cudaMemcpy(d_vec.data(), d_ptr, n * sizeof(type_t), cudaMemcpyDeviceToHost);
+  xpu::memcpy(d_vec.data(), d_ptr, n * sizeof(type_t),
+              xpu::memcpy_device_to_host);
 
   std::size_t error_count = 0;
   for (std::size_t i = 0; i < n; ++i) {

--- a/include/loops/util/equal.hxx
+++ b/include/loops/util/equal.hxx
@@ -16,7 +16,7 @@
 #include <iomanip>
 #include <limits>
 
-#include <loops/util/xpu.hxx>
+#include <loops/backend/xpu.hxx>
 
 #include <thrust/host_vector.h>
 

--- a/include/loops/util/launch.hxx
+++ b/include/loops/util/launch.hxx
@@ -11,7 +11,8 @@
 
 #pragma once
 #include <cstddef>
-#include <cuda.h>
+
+#include <loops/util/xpu.hxx>
 
 namespace loops {
 namespace launch {
@@ -29,7 +30,7 @@ inline void for_each_argument_address(void** collected_addresses,
 }  // namespace detail
 
 template <typename func_t, typename... args_t>
-void cooperative(cudaStream_t stream,
+void cooperative(xpu::stream_t stream,
                  const func_t& kernel,
                  std::size_t number_of_blocks,
                  std::size_t threads_per_block,
@@ -39,7 +40,7 @@ void cooperative(cudaStream_t stream,
   void* argument_ptrs[non_zero_num_params];
   detail::for_each_argument_address(argument_ptrs,
                                     ::std::forward<args_t>(args)...);
-  cudaLaunchCooperativeKernel<func_t>(
+  xpu::launch_cooperative_kernel<func_t>(
       &kernel, number_of_blocks, threads_per_block, argument_ptrs, 0, stream);
 }
 
@@ -64,7 +65,7 @@ void cooperative(cudaStream_t stream,
  * \return void
  */
 template <typename func_t, typename... args_t>
-void non_cooperative(cudaStream_t stream,
+void non_cooperative(xpu::stream_t stream,
                      const func_t& kernel,
                      dim3 number_of_blocks,
                      dim3 threads_per_block,

--- a/include/loops/util/launch.hxx
+++ b/include/loops/util/launch.hxx
@@ -12,7 +12,7 @@
 #pragma once
 #include <cstddef>
 
-#include <loops/util/xpu.hxx>
+#include <loops/backend/xpu.hxx>
 
 namespace loops {
 namespace launch {

--- a/include/loops/util/launch_box.hxx
+++ b/include/loops/util/launch_box.hxx
@@ -12,8 +12,10 @@
  * unmatched; a box with neither a match nor a fallback is ill-formed.
  *
  * The flag space is vendor-neutral: NVIDIA @c sm_* bits occupy the low range
- * and the remainder is reserved for AMD @c gfx ISAs, so a HIP build adds flags
- * rather than a parallel mechanism.
+ * and the high range carries AMD @c gfx ISAs, so a HIP build adds flags rather
+ * than a parallel mechanism. CUDA builds key the match off @c LOOPS_TARGET_ARCH
+ * (compute capability), HIP builds off @c LOOPS_TARGET_GFX (the gfx id as a hex
+ * literal, e.g. @c 0x942 for gfx942); both are threaded through from CMake.
  *
  * @copyright Copyright (c) 2026
  *
@@ -24,23 +26,27 @@
 #include <cstddef>
 #include <type_traits>
 
-#include <cuda_runtime.h>
-
+#include <loops/util/xpu.hxx>
 #include <loops/util/device.hxx>
 
 namespace loops {
 namespace launch_box {
 
 /**
- * @brief SM architecture flags.
+ * @brief Architecture flags (NVIDIA @c sm_* and AMD @c gfx*).
  *
  * Combine with @c | to bind one launch config to several architectures (e.g.
- * @c sm_80 @c | @c sm_86 ). @c fallback matches any architecture and belongs
- * last in a box. The bits above the NVIDIA range are reserved for AMD @c gfx
- * ISAs (gfx90a, gfx942, gfx950, RDNA) so they drop in as further flags.
+ * @c sm_80 @c | @c sm_86 , or @c gfx90a @c | @c gfx942 ). @c fallback matches
+ * any architecture and belongs last in a box. NVIDIA bits occupy the low
+ * range; AMD @c gfx bits start at 1u<<16 so both vendors coexist in one box.
+ *
+ * AMD families: CDNA (datacenter Instinct, wavefront 64) -- gfx906 MI50/60,
+ * gfx908 MI100, gfx90a MI210/MI250, gfx942 MI300/MI325, gfx950 MI350; RDNA
+ * (Radeon, native wave32) -- gfx1030 RDNA2, gfx1100 RDNA3, gfx1200 RDNA4.
  */
 enum sm_flag_t : unsigned int {
   fallback = 1u << 0,
+  // NVIDIA SM (compute capability).
   sm_70 = 1u << 1,
   sm_72 = 1u << 2,
   sm_75 = 1u << 3,
@@ -49,6 +55,16 @@ enum sm_flag_t : unsigned int {
   sm_89 = 1u << 6,
   sm_90 = 1u << 7,
   sm_100 = 1u << 8,
+  // AMD CDNA (Instinct, wavefront 64).
+  gfx906 = 1u << 16,
+  gfx908 = 1u << 17,
+  gfx90a = 1u << 18,
+  gfx942 = 1u << 19,
+  gfx950 = 1u << 20,
+  // AMD RDNA (Radeon, native wave32).
+  gfx1030 = 1u << 21,
+  gfx1100 = 1u << 22,
+  gfx1200 = 1u << 23,
 };
 
 constexpr sm_flag_t operator|(sm_flag_t a, sm_flag_t b) {
@@ -86,14 +102,47 @@ constexpr sm_flag_t flag_of(int compute_capability) {
   }
 }
 
-/// Architecture the kernels are compiled for. CMake pins it from a single-arch
-/// preset (release-a100 -> 80); multi-arch / native builds leave it at the
-/// Ampere floor and lean on each box's @c fallback entry.
+/// @c gfx flag for a gfx id given as a hex literal (0x942 -> @c gfx942 ). An
+/// unrecognized value carries no bit, so only a @c fallback entry can match it.
+constexpr sm_flag_t flag_of_gfx(int gfx) {
+  switch (gfx) {
+    case 0x906:
+      return gfx906;
+    case 0x908:
+      return gfx908;
+    case 0x90a:
+      return gfx90a;
+    case 0x942:
+      return gfx942;
+    case 0x950:
+      return gfx950;
+    case 0x1030:
+      return gfx1030;
+    case 0x1100:
+      return gfx1100;
+    case 0x1200:
+      return gfx1200;
+    default:
+      return static_cast<sm_flag_t>(0u);
+  }
+}
+
+/// Architecture the kernels are compiled for. A single-arch preset pins it
+/// exactly (release-a100 -> sm_80, release-mi300x -> gfx942); multi-arch /
+/// native builds leave it at the per-vendor floor and lean on each box's
+/// @c fallback entry. HIP builds key off @c LOOPS_TARGET_GFX , CUDA builds off
+/// @c LOOPS_TARGET_ARCH .
+#if defined(LOOPS_BACKEND_HIP)
+#ifndef LOOPS_TARGET_GFX
+#define LOOPS_TARGET_GFX 0x90a
+#endif
+constexpr sm_flag_t target_flag = flag_of_gfx(LOOPS_TARGET_GFX);
+#else
 #ifndef LOOPS_TARGET_ARCH
 #define LOOPS_TARGET_ARCH 80
 #endif
-
 constexpr sm_flag_t target_flag = flag_of(LOOPS_TARGET_ARCH);
+#endif
 
 /**
  * @brief Launch configuration for one or more SM architectures.
@@ -177,7 +226,7 @@ inline std::size_t occupancy_grid(const kernel_t& kernel,
                                   int block_size,
                                   std::size_t dynamic_shared_memory_bytes = 0) {
   int blocks_per_sm = 0;
-  cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+  xpu::occupancy_max_active_blocks_per_multiprocessor(
       &blocks_per_sm, kernel, block_size, dynamic_shared_memory_bytes);
   if (blocks_per_sm < 1)
     blocks_per_sm = 1;

--- a/include/loops/util/launch_box.hxx
+++ b/include/loops/util/launch_box.hxx
@@ -42,7 +42,8 @@ namespace launch_box {
  *
  * AMD families: CDNA (datacenter Instinct, wavefront 64) -- gfx906 MI50/60,
  * gfx908 MI100, gfx90a MI210/MI250, gfx942 MI300/MI325, gfx950 MI350; RDNA
- * (Radeon, native wave32) -- gfx1030 RDNA2, gfx1100 RDNA3, gfx1200 RDNA4.
+ * (Radeon, native wave32) -- gfx1030 RDNA2, gfx1100 RDNA3, gfx1200/gfx1201
+ * RDNA4. A future-CDNA (e.g. MI400) slot drops in as the next high bit.
  */
 enum sm_flag_t : unsigned int {
   fallback = 1u << 0,
@@ -65,6 +66,7 @@ enum sm_flag_t : unsigned int {
   gfx1030 = 1u << 21,
   gfx1100 = 1u << 22,
   gfx1200 = 1u << 23,
+  gfx1201 = 1u << 24,
 };
 
 constexpr sm_flag_t operator|(sm_flag_t a, sm_flag_t b) {
@@ -122,6 +124,8 @@ constexpr sm_flag_t flag_of_gfx(int gfx) {
       return gfx1100;
     case 0x1200:
       return gfx1200;
+    case 0x1201:
+      return gfx1201;
     default:
       return static_cast<sm_flag_t>(0u);
   }

--- a/include/loops/util/launch_box.hxx
+++ b/include/loops/util/launch_box.hxx
@@ -26,7 +26,7 @@
 #include <cstddef>
 #include <type_traits>
 
-#include <loops/util/xpu.hxx>
+#include <loops/backend/xpu.hxx>
 #include <loops/util/device.hxx>
 
 namespace loops {

--- a/include/loops/util/reference.hxx
+++ b/include/loops/util/reference.hxx
@@ -29,8 +29,7 @@
 #include <loops/container/csr.hxx>
 #include <loops/container/vector.hxx>
 #include <loops/memory.hxx>
-
-#include <cuda_runtime.h>
+#include <loops/util/xpu.hxx>
 
 #include <thrust/host_vector.h>
 
@@ -292,8 +291,8 @@ rigorous_report rigorously_validate_spmv(
       row_l1_products(csr_h, x_h);  // double L1 of products, cast to value_t
 
   thrust::host_vector<value_t> y_gpu(csr_h.rows);
-  cudaMemcpy(y_gpu.data(), d_y_gpu, csr_h.rows * sizeof(value_t),
-             cudaMemcpyDeviceToHost);
+  xpu::memcpy(y_gpu.data(), d_y_gpu, csr_h.rows * sizeof(value_t),
+              xpu::memcpy_device_to_host);
 
   rigorous_report report;
   report.total_rows = csr_h.rows;
@@ -362,7 +361,7 @@ std::size_t count_errors(const value_t* d_y,
                          ne_t ne,
                          bool verbose = false) {
   thrust::host_vector<value_t> y_h(n);
-  cudaMemcpy(y_h.data(), d_y, n * sizeof(value_t), cudaMemcpyDeviceToHost);
+  xpu::memcpy(y_h.data(), d_y, n * sizeof(value_t), xpu::memcpy_device_to_host);
 
   std::size_t errors = 0;
   for (std::size_t i = 0; i < n; ++i) {

--- a/include/loops/util/reference.hxx
+++ b/include/loops/util/reference.hxx
@@ -29,7 +29,7 @@
 #include <loops/container/csr.hxx>
 #include <loops/container/vector.hxx>
 #include <loops/memory.hxx>
-#include <loops/util/xpu.hxx>
+#include <loops/backend/xpu.hxx>
 
 #include <thrust/host_vector.h>
 

--- a/include/loops/util/timer.hxx
+++ b/include/loops/util/timer.hxx
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <cuda_runtime.h>
+#include <loops/util/xpu.hxx>
 
 namespace loops {
 namespace util {
@@ -20,25 +20,25 @@ struct timer_t {
   float time;
 
   timer_t() {
-    cudaEventCreate(&start_);
-    cudaEventCreate(&stop_);
-    cudaEventRecord(start_);
+    xpu::event_create(&start_);
+    xpu::event_create(&stop_);
+    xpu::event_record(start_);
   }
 
   ~timer_t() {
-    cudaEventDestroy(start_);
-    cudaEventDestroy(stop_);
+    xpu::event_destroy(start_);
+    xpu::event_destroy(stop_);
   }
 
   // Alias of each other, start the timer.
-  void begin() { cudaEventRecord(start_); }
+  void begin() { xpu::event_record(start_); }
   void start() { this->begin(); }
 
   // Alias of each other, stop the timer.
   float end() {
-    cudaEventRecord(stop_);
-    cudaEventSynchronize(stop_);
-    cudaEventElapsedTime(&time, start_, stop_);
+    xpu::event_record(stop_);
+    xpu::event_synchronize(stop_);
+    xpu::event_elapsed_time(&time, start_, stop_);
 
     return milliseconds();
   }
@@ -48,7 +48,7 @@ struct timer_t {
   float milliseconds() { return time; }
 
  private:
-  cudaEvent_t start_, stop_;
+  xpu::event_t start_, stop_;
 };
 
 }  // namespace util

--- a/include/loops/util/timer.hxx
+++ b/include/loops/util/timer.hxx
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <loops/util/xpu.hxx>
+#include <loops/backend/xpu.hxx>
 
 namespace loops {
 namespace util {

--- a/include/loops/util/xpu.hxx
+++ b/include/loops/util/xpu.hxx
@@ -1,0 +1,201 @@
+/**
+ * @file xpu.hxx
+ * @author Muhammad Osama (mosama@ucdavis.edu)
+ * @brief Vendor-neutral device runtime surface (CUDA or HIP).
+ * @version 0.1
+ * @date 2026-06-23
+ *
+ * Everything in loops talks to the device runtime through @c loops::xpu so the
+ * rest of the tree is not CUDA-specific: a CUDA build (nvcc) and a HIP build
+ * (hipcc, AMD ROCm) differ only inside this header. The two runtimes are nearly
+ * 1:1 -- @c cudaStreamSynchronize maps to @c hipStreamSynchronize ,
+ * @c cudaDeviceProp to @c hipDeviceProp_t -- so the shim stays thin: type
+ * aliases plus a token-pasted wrapper per call.
+ *
+ * Backend selection: CMake sets @c LOOPS_BACKEND_HIP (HIP) or
+ * @c LOOPS_BACKEND_CUDA (CUDA, the default). Absent an explicit choice we infer
+ * HIP when the AMD compiler defines @c __HIP_PLATFORM_AMD__ , otherwise CUDA, so
+ * existing nvcc builds are unaffected.
+ *
+ * @copyright Copyright (c) 2026
+ *
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#if !defined(LOOPS_BACKEND_HIP) && !defined(LOOPS_BACKEND_CUDA)
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+#define LOOPS_BACKEND_HIP
+#else
+#define LOOPS_BACKEND_CUDA
+#endif
+#endif
+
+#if defined(LOOPS_BACKEND_HIP)
+#include <hip/hip_runtime.h>
+#define LOOPS_XPU_(name) hip##name
+#else
+#include <cuda_runtime.h>
+#define LOOPS_XPU_(name) cuda##name
+#endif
+
+namespace loops {
+
+/**
+ * @namespace xpu
+ * The device-runtime backend. Names here read as the vendor-neutral verb
+ * (@c xpu::stream_synchronize ) and resolve to CUDA or HIP at compile time.
+ */
+namespace xpu {
+
+// ----- Types --------------------------------------------------------------
+#if defined(LOOPS_BACKEND_HIP)
+using error_t = hipError_t;
+using stream_t = hipStream_t;
+using event_t = hipEvent_t;
+using device_properties_t = hipDeviceProp_t;
+using memcpy_kind_t = hipMemcpyKind;
+using device_attribute_t = hipDeviceAttribute_t;
+#else
+using error_t = cudaError_t;
+using stream_t = cudaStream_t;
+using event_t = cudaEvent_t;
+using device_properties_t = cudaDeviceProp;
+using memcpy_kind_t = cudaMemcpyKind;
+using device_attribute_t = cudaDeviceAttr;
+#endif
+
+// ----- Constants ----------------------------------------------------------
+#if defined(LOOPS_BACKEND_HIP)
+inline constexpr error_t success = hipSuccess;
+
+inline constexpr memcpy_kind_t memcpy_host_to_device = hipMemcpyHostToDevice;
+inline constexpr memcpy_kind_t memcpy_device_to_host = hipMemcpyDeviceToHost;
+inline constexpr memcpy_kind_t memcpy_device_to_device =
+    hipMemcpyDeviceToDevice;
+
+inline constexpr device_attribute_t attr_multiprocessor_count =
+    hipDeviceAttributeMultiprocessorCount;
+inline constexpr device_attribute_t attr_compute_capability_major =
+    hipDeviceAttributeComputeCapabilityMajor;
+inline constexpr device_attribute_t attr_compute_capability_minor =
+    hipDeviceAttributeComputeCapabilityMinor;
+inline constexpr device_attribute_t attr_max_grid_dim_x =
+    hipDeviceAttributeMaxGridDimX;
+#else
+inline constexpr error_t success = cudaSuccess;
+
+inline constexpr memcpy_kind_t memcpy_host_to_device = cudaMemcpyHostToDevice;
+inline constexpr memcpy_kind_t memcpy_device_to_host = cudaMemcpyDeviceToHost;
+inline constexpr memcpy_kind_t memcpy_device_to_device =
+    cudaMemcpyDeviceToDevice;
+
+inline constexpr device_attribute_t attr_multiprocessor_count =
+    cudaDevAttrMultiProcessorCount;
+inline constexpr device_attribute_t attr_compute_capability_major =
+    cudaDevAttrComputeCapabilityMajor;
+inline constexpr device_attribute_t attr_compute_capability_minor =
+    cudaDevAttrComputeCapabilityMinor;
+inline constexpr device_attribute_t attr_max_grid_dim_x =
+    cudaDevAttrMaxGridDimX;
+#endif
+
+// ----- Device management --------------------------------------------------
+inline error_t set_device(int ordinal) {
+  return LOOPS_XPU_(SetDevice)(ordinal);
+}
+
+inline error_t get_device(int* ordinal) {
+  return LOOPS_XPU_(GetDevice)(ordinal);
+}
+
+inline error_t get_device_properties(device_properties_t* props, int ordinal) {
+  return LOOPS_XPU_(GetDeviceProperties)(props, ordinal);
+}
+
+inline error_t device_get_attribute(int* value,
+                                    device_attribute_t attr,
+                                    int ordinal) {
+  return LOOPS_XPU_(DeviceGetAttribute)(value, attr, ordinal);
+}
+
+inline error_t device_synchronize() {
+  return LOOPS_XPU_(DeviceSynchronize)();
+}
+
+// ----- Memory -------------------------------------------------------------
+inline error_t malloc(void** ptr, std::size_t bytes) {
+  return LOOPS_XPU_(Malloc)(ptr, bytes);
+}
+
+inline error_t free(void* ptr) {
+  return LOOPS_XPU_(Free)(ptr);
+}
+
+inline error_t memcpy(void* dst,
+                      const void* src,
+                      std::size_t bytes,
+                      memcpy_kind_t kind) {
+  return LOOPS_XPU_(Memcpy)(dst, src, bytes, kind);
+}
+
+// ----- Streams ------------------------------------------------------------
+inline error_t stream_synchronize(stream_t stream = 0) {
+  return LOOPS_XPU_(StreamSynchronize)(stream);
+}
+
+// ----- Events -------------------------------------------------------------
+inline error_t event_create(event_t* event) {
+  return LOOPS_XPU_(EventCreate)(event);
+}
+
+inline error_t event_destroy(event_t event) {
+  return LOOPS_XPU_(EventDestroy)(event);
+}
+
+inline error_t event_record(event_t event, stream_t stream = 0) {
+  return LOOPS_XPU_(EventRecord)(event, stream);
+}
+
+inline error_t event_synchronize(event_t event) {
+  return LOOPS_XPU_(EventSynchronize)(event);
+}
+
+inline error_t event_elapsed_time(float* ms, event_t start, event_t stop) {
+  return LOOPS_XPU_(EventElapsedTime)(ms, start, stop);
+}
+
+// ----- Errors -------------------------------------------------------------
+inline const char* get_error_string(error_t status) {
+  return LOOPS_XPU_(GetErrorString)(status);
+}
+
+// ----- Occupancy ----------------------------------------------------------
+/// Max resident blocks per multiprocessor (SM / CU) for @p kernel; the launch
+/// boxes turn this into a one-wave grid.
+template <typename kernel_t>
+inline error_t occupancy_max_active_blocks_per_multiprocessor(
+    int* blocks_per_sm,
+    kernel_t kernel,
+    int block_size,
+    std::size_t dynamic_shared_memory_bytes) {
+  return LOOPS_XPU_(OccupancyMaxActiveBlocksPerMultiprocessor)(
+      blocks_per_sm, kernel, block_size, dynamic_shared_memory_bytes);
+}
+
+// ----- Cooperative launch -------------------------------------------------
+template <typename func_t>
+inline error_t launch_cooperative_kernel(const func_t* kernel,
+                                         dim3 grid_dim,
+                                         dim3 block_dim,
+                                         void** args,
+                                         std::size_t shared_memory_bytes,
+                                         stream_t stream) {
+  return LOOPS_XPU_(LaunchCooperativeKernel)<func_t>(
+      kernel, grid_dim, block_dim, args, shared_memory_bytes, stream);
+}
+
+}  // namespace xpu
+}  // namespace loops


### PR DESCRIPTION
This pull request introduces comprehensive support for building and running the project on AMD GPUs using the HIP/ROCm backend, in addition to the existing CUDA/NVIDIA support. The changes include backend selection in the build system, new CMake presets for AMD architectures, CI integration for HIP builds, and code updates to ensure backend-agnostic usage of GPU streams and synchronization. Some CUDA-specific examples are now conditionally excluded from HIP builds.

**Build system and configuration:**

* Added a `LOOPS_BACKEND` CMake option to select between CUDA (default) and HIP backends, with corresponding logic for toolkit and architecture selection, dependency finding, compile flags, and target properties in `CMakeLists.txt`. This enables seamless building on either NVIDIA or AMD platforms. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR7-R15) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL21-R56) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR72-R81) [[4]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL65-R114) [[5]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL84-R149) [[6]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR158-R161) [[7]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR176) [[8]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR206-R247) [[9]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR258)
* Added new CMake presets for AMD GPUs (gfx90a, gfx942, gfx950) in `CMakePresets.json`, enabling easy configuration and build for MI210/MI250, MI300X/MI325X, and MI350X architectures. [[1]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R83-R115) [[2]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R154-R168)

**Continuous Integration:**

* Introduced a new GitHub Actions job for backend parity, which checks for symbol mismatches between CUDA and HIP backend headers, ensuring API consistency. Also added a HIP build job targeting multiple AMD architectures, installing necessary ROCm tools and compiling the code in CI. (`.github/workflows/build.yml`)

**Codebase portability and backend-agnostic changes:**

* Updated all relevant algorithm implementations and examples to use `xpu::stream_t` and `xpu::stream_synchronize` instead of CUDA-specific types and functions, allowing the same code to work with both CUDA and HIP backends. [[1]](diffhunk://#diff-b73b0a7d3a14d9ea7d6aee368a4e737dfac29f4454182673724dd751d4318d95L235-R235) [[2]](diffhunk://#diff-acd42e311a45700ecb674632abb0f76be7bc13a12e6a54e7dd23e778a398fccaL71-R71) [[3]](diffhunk://#diff-acd42e311a45700ecb674632abb0f76be7bc13a12e6a54e7dd23e778a398fccaL89-R89) [[4]](diffhunk://#diff-c7417687f9c5bc4d605177c7d7ee867cb4b1e95831311b0c531963880b4b00e3L96-R96) [[5]](diffhunk://#diff-c7417687f9c5bc4d605177c7d7ee867cb4b1e95831311b0c531963880b4b00e3L120-R120) [[6]](diffhunk://#diff-3a6e08ea6e9d9fc7941c6a93efe149fd196b16183c809b18390a3413c9ee729eL63-R63) [[7]](diffhunk://#diff-3a6e08ea6e9d9fc7941c6a93efe149fd196b16183c809b18390a3413c9ee729eL86-R86) [[8]](diffhunk://#diff-39474c6bab4aa1027c1f0d248334e6628b6dd5f8a17d82471a72e5cf3fa850aeL62-R62)

**Conditional example inclusion:**

* Modified the SPMV example CMakeLists to exclude the `group_mapped.cu` example when building with HIP, as it relies on NVIDIA cooperative-groups, which are not available in HIP. [[1]](diffhunk://#diff-35da80d133edf609c6cc7b83a9af5ac7625274fae2a8a18ebb8dcf2b43a99fa4L4) [[2]](diffhunk://#diff-35da80d133edf609c6cc7b83a9af5ac7625274fae2a8a18ebb8dcf2b43a99fa4R16-R22)

These changes collectively enable robust, cross-vendor GPU support and improve maintainability and CI coverage for both CUDA and HIP backends.